### PR TITLE
Add Cloudflare Web Analytics snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,5 +135,8 @@
 
     <script src="assets/data.js?v=20260425-7"></script>
     <script src="assets/app.js?v=20260425-7"></script>
+    <!-- Cloudflare Web Analytics -->
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "ef2305f18ca64c5dab2f9a0f2eccdabe"}'></script>
+    <!-- End Cloudflare Web Analytics -->
   </body>
 </html>


### PR DESCRIPTION
Adds the Cloudflare Web Analytics beacon snippet to index.html (right before </body>) so page views and visits on https://sum-lab.github.io/youtube-monetization-watch/ can be measured. No other changes.